### PR TITLE
Ensure that conf is not nil (fixes #10)

### DIFF
--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -279,7 +279,7 @@ local function setup(config)
     return
   end
 
-  local conf = vim.deepcopy(config)
+  local conf = vim.deepcopy(config) or {}
 
   -- if nothing given the enable for all filetypes
   local filetypes = conf.filetypes or conf[1] or { "*" }


### PR DESCRIPTION
Bug #10 happens if nvim-colorizer is called without a config table. This should fix that case.