### PR TITLE
Add missing space in README's setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ every filetype.
 **NOTE**: You should add this line after/below where your plugins are setup.
 
 ```lua
-require'colorizer'.setup()
+require 'colorizer'.setup()
 ```
 
 ### Use with commands


### PR DESCRIPTION
Just a simple typo fix. Thanks for the great tool.