### PR TITLE
Combine background color for `virtualtext`

### DIFF
--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -112,6 +112,7 @@ function buffer.add_highlight(buf, ns, line_start, line_end, data, options)
         buf_set_virtual_text(0, ns, linenr, hl.range[2], {
           end_col = hl.range[2],
           virt_text = { { options.virtualtext or "■", hlname } },
+          hl_mode = "combine",
         })
       end
     end


### PR DESCRIPTION
# Goal

Combine the background highlight color when using virtual text for cases such as cursor line with the `hl_mode = "combine"` option for `nvim_buf_set_extmark`.

I use a highlighted cursor line and when using the `virtualtext` mode, the background color is removed from the colorizer highlight and causes a break in the cursor line.

Here are some screenshots. Check the virtual text ` ` on line 26 for both.

### Existing highlight

![2022-10-06T11-39-21-812296675](https://user-images.githubusercontent.com/32845348/194358860-5f9e8ae8-22f7-485d-94e3-c45c56b01f0f.png)

### Highlight with `hl_mode = "combine"` applied

![2022-10-06T11-46-45-540741499](https://user-images.githubusercontent.com/32845348/194358978-7447c470-692b-4665-b233-b53b29ecaef6.png)

This minor change just applies the `hl_mode` option to the `nvim_buf_set_extmark` or `buf_set_virtual_text` function call. The following is from the `:h nvim_buf_set_extmark()` docs.

```help
• hl_mode : control how highlights are combined with the
  highlights of the text. Currently only affects virt_text
  highlights, but might affect `hl_group` in later versions.
  • "replace": only show the virt_text color. This is the
    default
  • "combine": combine with background text color
  • "blend": blend with background text color.
```

I believe this is the only place to make this change and shouldn't affect anything else.