### PR TITLE
docs: fix unquoted string in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ library to do custom highlighting themselves.
         -- True is same as normal
         tailwind = false, -- Enable tailwind colors
         -- parsers can contain values used in |user_default_options|
-        sass = { enable = false, parsers = { css }, }, -- Enable sass colors
+        sass = { enable = false, parsers = { "css" }, }, -- Enable sass colors
         virtualtext = "■",
       },
       -- all the sub-options of filetypes apply to buftypes


### PR DESCRIPTION
I believe `css` should be `"css"` because it should be a string value.