### PR TITLE
feat: Add inline virtualtext mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ library to do custom highlighting themselves.
         hsl_fn = false, -- CSS hsl() and hsla() functions
         css = false, -- Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB
         css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
-        -- Available modes for `mode`: foreground, background,  virtualtext
+        -- Available modes for `mode`: foreground, background,  virtualtext, inline
         mode = "background", -- Set the display mode.
         -- Available methods are false / true / "normal" / "lsp" / "both"
         -- True is same as normal
@@ -114,6 +114,7 @@ MODES:
 - `foreground`: sets the foreground text color.
 - `background`: sets the background text color.
 - `virtualtext`: indicate the color behind the virtualtext.
+- `inline`: indicate the color with inline virtualtext (Neovim v0.10+).
 
 For basic setup, you can use a command like the following.
 

--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -35,6 +35,7 @@ buffer.highlight_mode_names = {
   background = "mb",
   foreground = "mf",
   virtualtext = "mv",
+  inline = "mv",
 }
 
 --- Clean the highlight cache
@@ -105,15 +106,20 @@ function buffer.add_highlight(buf, ns, line_start, line_end, data, options)
         api.nvim_buf_add_highlight(buf, ns, hlname, linenr, hl.range[1], hl.range[2])
       end
     end
-  elseif options.mode == "virtualtext" then
+  elseif options.mode == "virtualtext" or options.mode == "inline" then
     for linenr, hls in pairs(data) do
       for _, hl in ipairs(hls) do
         local hlname = create_highlight(hl.rgb_hex, mode)
-        buf_set_virtual_text(buf, ns, linenr, hl.range[2], {
-          end_col = hl.range[2],
+        local opts = {
           virt_text = { { options.virtualtext or "■", hlname } },
           hl_mode = "combine",
-        })
+        }
+        if options.mode == "virtualtext" then
+          opts.end_col = hl.range[2]
+        elseif options.mode == "inline" then
+          opts.virt_text_pos = "inline"
+        end
+        buf_set_virtual_text(buf, ns, linenr, hl.range[2], opts)
       end
     end
   end


### PR DESCRIPTION
This adds a new `inline` mode to use the new inline virtual text features of Neovim v0.10 (currently nightly)

![2023-05-23_11:45:53_screenshot](https://github.com/NvChad/nvim-colorizer.lua/assets/1591837/a9dadd3f-4c3e-4024-b860-a36f42b3a464)
