### PR TITLE
feat: add ring, ring-offset to tailwind prefixes

### DIFF
--- a/lua/colorizer/tailwind_colors.lua
+++ b/lua/colorizer/tailwind_colors.lua
@@ -21,6 +21,8 @@ return {
     "text",
     "to",
     "via",
+    "ring",
+    "ring-offset",
   },
   -- Generated using https://github.com/tailwindlabs/tailwindcss/raw/master/src/public/colors.js
   colors = {


### PR DESCRIPTION
Adds ring, ring-offset to tailwind prefixes:

![image](https://github.com/NvChad/nvim-colorizer.lua/assets/21010072/98bfd617-4641-4948-b7c5-9c1ce767395c)
