### PR TITLE
fix: removed use of deprecated vim.lsp.get_active_clients

### DIFF
--- a/lua/colorizer/tailwind.lua
+++ b/lua/colorizer/tailwind.lua
@@ -115,7 +115,7 @@ function tailwind.setup_lsp_colors(buf, options, options_local, add_highlight)
     TAILWIND[buf].CLIENT = nil
 
     local ok, tailwind_client = pcall(function()
-      return vim.lsp.get_active_clients { bufnr = buf, name = "tailwindcss" }
+      return vim.lsp.get_clients { bufnr = buf, name = "tailwindcss" }
     end)
     if not ok then
       return


### PR DESCRIPTION
Hello!

This removes use of the `vim.lsp.get_active_clients` function which was deprecated in Neovim 10.

Closes #80 

Thanks!