### PR TITLE
Fix/buffer.clear_hl_cache calling unknown function

### DIFF
--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -98,6 +98,9 @@ Functions: ~
     |setup| - Easy to use function if you want the full setup without fine
     grained control.
 
+    |clear_highlight_cache| - Clears the highlight cache and reloads all
+    buffers.
+
 Fields: ~
     |default_namespace| - Default namespace used in `colorizer.buffer.highlight`
     and `attach_to_buffer`.
@@ -199,6 +202,11 @@ setup({opts})                                                  *colorizer.setup*
 
     Usage:~
 	`require("colorizer").setup()`
+
+
+
+clear_highlight_cache()                        *colorizer.clear_highlight_cache*
+    Clears the highlight cache and reloads all buffers.
 
 
 

--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -234,8 +234,6 @@ Functions: ~
     containing
  rgb_hex and range per line
 
-    |clear_highlight_cache| - Clear the highlight cache and reload all buffers.
-
 Tables: ~
     |highlight_mode_names| - Highlight mode which will be use to render the
     color
@@ -278,8 +276,8 @@ highlight({bufnr}, {ns_id}, {line_start}, {line_end}, {options},
 
 
     Parameters: ~
-	{bufnr} -  number: buffer number (0 for current)
-	{ns_id} -  number: namespace id.  default is "colorizer", created with
+	{bufnr} -  number: Buffer number, 0 for current
+	{ns_id} -  number: Namespace id, default is "colorizer" created with
 	vim.api.nvim_create_namespace
 	{line_start} -  number: line_start should be 0-indexed
 	{line_end} -  number: Last line to highlight
@@ -298,8 +296,8 @@ parse_lines({bufnr}, {lines}, {line_start}, {options})
      rgb_hex and range per line
 
     Parameters: ~
-	{bufnr} -  number: buffer number (0 for current)
-	{lines} -  table: table of lines to parse
+	{bufnr} -  number: Buffer number (0 for current)
+	{lines} -  table: Table of lines to parse
 	{line_start} -  number: This is the buffer line number, from where to
 	start highlighting
 	{options} -  table: Passed in `colorizer.setup`, Only uses
@@ -307,11 +305,6 @@ parse_lines({bufnr}, {lines}, {line_start}, {options})
 
     returns:~
 	table or nil
-
-
-
-clear_highlight_cache()                 *colorizer.buffer.clear_highlight_cache*
-    Clear the highlight cache and reload all buffers.
 
 
 
@@ -868,7 +861,7 @@ name_parser({line}, {i}, {bufnr})                   *colorizer.sass.name_parser*
     Parameters: ~
 	{line} -  string: Line to parse
 	{i} -  number: Index of line from where to start parsing
-	{bufnr} -  number
+	{bufnr} -  number: Buffer number
 
     returns:~
 	number or nil, string or nil
@@ -887,7 +880,7 @@ update_variables({bufnr}, {line_start}, {line_end}, {lines}, {color_parser},
 
 
     Parameters: ~
-	{bufnr} -  number: buffer number (0 for current)
+	{bufnr} -  number: Buffer number
 	{line_start} -  number
 	{line_end} -  number
 	{lines} -  table|nil
@@ -933,7 +926,7 @@ setup_lsp_colors({bufnr}, {options}, {options_local}, {add_highlight})
      To see these table information, see |colorizer.buffer|
 
     Parameters: ~
-	{bufnr} -  number: buffer number (0 for current)
+	{bufnr} -  number: Buffer number (0 for current)
 	{options} -  table
 	{options_local} -  table
 	{add_highlight} -  function

--- a/doc/modules/colorizer.buffer.html
+++ b/doc/modules/colorizer.buffer.html
@@ -86,10 +86,6 @@
 	<td class="summary">Parse the given lines for colors and return a table containing
  rgb_hex and range per line</td>
 	</tr>
-	<tr>
-	<td class="name" nowrap><a href="#clear_highlight_cache">clear_highlight_cache ()</a></td>
-	<td class="summary">Clear the highlight cache and reload all buffers.</td>
-	</tr>
 </table>
 <h2><a href="#Tables">Tables</a></h2>
 <table class="function_list">
@@ -175,10 +171,10 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">bufnr</span>
-         number: buffer number (0 for current)
+         number: Buffer number, 0 for current
         </li>
         <li><span class="parameter">ns_id</span>
-         number: namespace id.  default is "colorizer", created with vim.api.nvim_create_namespace
+         number: Namespace id, default is "colorizer" created with vim.api.nvim_create_namespace
         </li>
         <li><span class="parameter">line_start</span>
          number: line_start should be 0-indexed
@@ -216,10 +212,10 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">bufnr</span>
-         number: buffer number (0 for current)
+         number: Buffer number (0 for current)
         </li>
         <li><span class="parameter">lines</span>
-         table: table of lines to parse
+         table: Table of lines to parse
         </li>
         <li><span class="parameter">line_start</span>
          number: This is the buffer line number, from where to start highlighting
@@ -234,20 +230,6 @@
 
         table|nil
     </ol>
-
-
-
-
-</dd>
-    <dt>
-    <a name = "clear_highlight_cache"></a>
-    <strong>clear_highlight_cache ()</strong>
-    </dt>
-    <dd>
-    Clear the highlight cache and reload all buffers.
-
-
-
 
 
 

--- a/doc/modules/colorizer.html
+++ b/doc/modules/colorizer.html
@@ -174,6 +174,10 @@ Detach
 	<td class="name" nowrap><a href="#setup">setup (opts)</a></td>
 	<td class="summary">Easy to use function if you want the full setup without fine grained control.</td>
 	</tr>
+	<tr>
+	<td class="name" nowrap><a href="#clear_highlight_cache">clear_highlight_cache ()</a></td>
+	<td class="summary">Clears the highlight cache and reloads all buffers.</td>
+	</tr>
 </table>
 <h2><a href="#Fields">Fields</a></h2>
 <table class="function_list">
@@ -374,6 +378,20 @@ Setup colorizer with user options
     <ul>
         <pre class="example"><span class="backtick">`require("colorizer").setup()`</span></pre>
     </ul>
+
+</dd>
+    <dt>
+    <a name = "clear_highlight_cache"></a>
+    <strong>clear_highlight_cache ()</strong>
+    </dt>
+    <dd>
+    Clears the highlight cache and reloads all buffers.
+
+
+
+
+
+
 
 </dd>
 </dl>

--- a/doc/modules/colorizer.sass.html
+++ b/doc/modules/colorizer.sass.html
@@ -130,7 +130,7 @@
          number: Index of line from where to start parsing
         </li>
         <li><span class="parameter">bufnr</span>
-         number
+         number: Buffer number
         </li>
     </ul>
 
@@ -157,7 +157,7 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">bufnr</span>
-         number: buffer number (0 for current)
+         number: Buffer number
         </li>
         <li><span class="parameter">line_start</span>
          number

--- a/doc/modules/colorizer.tailwind.html
+++ b/doc/modules/colorizer.tailwind.html
@@ -120,7 +120,7 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">bufnr</span>
-         number: buffer number (0 for current)
+         number: Buffer number (0 for current)
         </li>
         <li><span class="parameter">options</span>
          table

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -486,6 +486,7 @@ function M.setup(opts)
   require("colorizer.usercmds").make(s.user_commands)
 end
 
+--- Clears the highlight cache and reloads all buffers.
 function M.clear_highlight_cache()
   buffer.clear_hl_cache()
   vim.schedule(M.reload_all_buffers)

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -478,7 +478,8 @@ function M.setup(opts)
   vim.api.nvim_create_autocmd("ColorScheme", {
     group = colorizer_state.augroup,
     callback = function()
-      buffer.clear_highlight_cache()
+      utils.clear_hl_cache()
+      vim.schedule(M.reload_all_buffers)
     end,
   })
 

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -477,16 +477,18 @@ function M.setup(opts)
 
   vim.api.nvim_create_autocmd("ColorScheme", {
     group = colorizer_state.augroup,
-    callback = function()
-      utils.clear_hl_cache()
-      vim.schedule(M.reload_all_buffers)
-    end,
+    callback = M.clear_highlight_cache,
   })
 
   parse_opts("filetype", s.filetypes)
   parse_opts("buftype", s.buftypes)
 
   require("colorizer.usercmds").make(s.user_commands)
+end
+
+function M.clear_highlight_cache()
+  buffer.clear_hl_cache()
+  vim.schedule(M.reload_all_buffers)
 end
 
 return M

--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -204,10 +204,4 @@ function M.parse_lines(bufnr, lines, line_start, options)
   return data
 end
 
---- Clear the highlight cache and reload all buffers.
-function M.clear_highlight_cache()
-  utils.clear_hl_cache()
-  vim.schedule(buffer.reload_all_buffers)
-end
-
 return M

--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -7,7 +7,6 @@ local color = require("colorizer.color")
 local plugin_name = "colorizer"
 local sass = require("colorizer.sass")
 local tailwind = require("colorizer.tailwind")
-local utils = require("colorizer.utils")
 local make_matcher = require("colorizer.matcher").make
 
 local hl_state = {

--- a/lua/colorizer/parser/argb_hex.lua
+++ b/lua/colorizer/parser/argb_hex.lua
@@ -48,6 +48,7 @@ function M.argb_hex_parser(line, i)
 
   local length = j - i
 
+  local r, g, b
   if length == 10 then -- 0xAARRGGBB
     alpha = band(rshift(v, 24), 0xFF) / 255
     r = floor(band(rshift(v, 16), 0xFF) * alpha)
@@ -66,9 +67,9 @@ function M.argb_hex_parser(line, i)
   end
 
   alpha = tonumber(alpha) / 255
-  local r = floor(band(rshift(v, 16), 0xFF) * alpha)
-  local g = floor(band(rshift(v, 8), 0xFF) * alpha)
-  local b = floor(band(v, 0xFF) * alpha)
+  r = floor(band(rshift(v, 16), 0xFF) * alpha)
+  g = floor(band(rshift(v, 8), 0xFF) * alpha)
+  b = floor(band(v, 0xFF) * alpha)
   local rgb_hex = string.format("%02x%02x%02x", r, g, b)
   return length, rgb_hex
 end

--- a/lua/colorizer/parser/argb_hex.lua
+++ b/lua/colorizer/parser/argb_hex.lua
@@ -5,11 +5,10 @@
 local M = {}
 
 local bit = require("bit")
-local utils = require("colorizer.utils")
 local floor, min = math.floor, math.min
 local band, rshift, lshift = bit.band, bit.rshift, bit.lshift
 
-local argb_minimum_length = #"0xAARRGGBB" - 1
+local utils = require("colorizer.utils")
 
 --- Parses a `0xAARRGGBB` formatted hexadecimal color and converts it to an RGB hex value.
 -- This function reads a color from a line of text, expecting it in the `0xAARRGGBB` format (common in Android apps).
@@ -20,56 +19,58 @@ local argb_minimum_length = #"0xAARRGGBB" - 1
 -- @return number|nil The end index of the parsed hex value within the line, or `nil` if parsing failed
 -- @return string|nil The RGB hexadecimal color (e.g., "ff0000" for red), or `nil` if parsing failed
 function M.argb_hex_parser(line, i)
-  if #line < i + argb_minimum_length then
+  -- Minimum length of a valid hex color (e.g., "0xRGB")
+  local minlen = #"0xRGB" - 1
+  -- Maximum length of a valid hex color (e.g., "0xAARRGGBB")
+  local maxlen = #"0xAARRGGBB" - 1
+
+  -- Ensure the line has enough characters to contain a valid hex color
+  if #line < i + minlen then
     return
   end
 
-  local j = i + 2
-  local n = j + 8
-  local alpha
-  local v = 0
+  local j = i + 2 -- Skip the "0x" prefix
+  local n = j + maxlen
+  local alpha, r, g, b
+  local v = 0 -- Holds the parsed value
 
+  -- Parse the hex characters starting from the given index
   while j <= min(n, #line) do
-    local b = line:byte(j)
-    if not utils.byte_is_hex(b) then
+    local byte = line:byte(j)
+    -- Stop parsing if the character is not a valid hex digit
+    if not utils.byte_is_hex(byte) then
       break
     end
-    if j - i <= 3 then
-      alpha = utils.parse_hex(b) + lshift(alpha or 0, 4)
-    else
-      v = utils.parse_hex(b) + lshift(v, 4)
-    end
+    -- Shift the current value left by 4 bits and add the parsed hex digit
+    v = utils.parse_hex(byte) + lshift(v, 4)
     j = j + 1
   end
 
+  -- If the next character is alphanumeric, the value is invalid
   if #line >= j and utils.byte_is_alphanumeric(line:byte(j)) then
     return
   end
 
-  local length = j - i
+  local length = j - i -- Calculate the length of the parsed hex value
 
-  local r, g, b
+  -- Parse the color components based on the detected length
   if length == 10 then -- 0xAARRGGBB
-    alpha = band(rshift(v, 24), 0xFF) / 255
-    r = floor(band(rshift(v, 16), 0xFF) * alpha)
-    g = floor(band(rshift(v, 8), 0xFF) * alpha)
-    b = floor(band(v, 0xFF) * alpha)
+    alpha = band(rshift(v, 24), 0xFF) / 255 -- Extract and normalize the alpha value
+    r = floor(band(rshift(v, 16), 0xFF) * alpha) -- Apply alpha to red
+    g = floor(band(rshift(v, 8), 0xFF) * alpha) -- Apply alpha to green
+    b = floor(band(v, 0xFF) * alpha) -- Apply alpha to blue
   elseif length == 8 then -- 0xRRGGBB
-    r = band(rshift(v, 16), 0xFF)
-    g = band(rshift(v, 8), 0xFF)
-    b = band(v, 0xFF)
+    r = band(rshift(v, 16), 0xFF) -- Extract red
+    g = band(rshift(v, 8), 0xFF) -- Extract green
+    b = band(v, 0xFF) -- Extract blue
   elseif length == 5 then -- 0xRGB
-    r = band(rshift(v, 8), 0xF) * 17
-    g = band(rshift(v, 4), 0xF) * 17
-    b = band(v, 0xF) * 17
+    r = band(rshift(v, 8), 0xF) * 17 -- Scale single hex digit to full byte
+    g = band(rshift(v, 4), 0xF) * 17 -- Scale single hex digit to full byte
+    b = band(v, 0xF) * 17 -- Scale single hex digit to full byte
   else
     return
   end
 
-  alpha = tonumber(alpha) / 255
-  r = floor(band(rshift(v, 16), 0xFF) * alpha)
-  g = floor(band(rshift(v, 8), 0xFF) * alpha)
-  b = floor(band(v, 0xFF) * alpha)
   local rgb_hex = string.format("%02x%02x%02x", r, g, b)
   return length, rgb_hex
 end


### PR DESCRIPTION
- Calls buffer.clear_hl_cache correctly
- Fixes issue with `AARRGGBB` not displaying `0xRRGGBB` or `0xRGB` correctly