### PR TITLE
feat: adds virtualtext_mode configuration in setup opts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+; http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+max_line_length = 120
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ use("NvChad/nvim-colorizer.lua")
 One line setup. This will create an `autocmd` for `FileType *` to highlight
 every filetype.
 
-**NOTE**: You should add this line after/below where your plugins are setup.
+> [!NOTE]
+> You should add this line after/below where your plugins are setup.
 
 ```lua
 require("colorizer").setup()
@@ -75,6 +76,9 @@ require("colorizer").setup()
 | **ColorizerDetachFromBuffer** | Stop highlighting the current buffer                        |
 | **ColorizerReloadAllBuffers** | Reload all buffers that are being highlighted currently     |
 | **ColorizerToggle**           | Toggle highlighting of the current buffer                   |
+
+> [!NOTE]
+> User commands can be enabled/disabled in setup opts
 
 ### Lua API
 
@@ -112,7 +116,8 @@ library to do custom highlighting themselves.
 
 ## Customization
 
-**Note**: These are the default options
+> [!NOTE]
+> These are the default options
 
 ```lua
   require("colorizer").setup({

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Use your plugin manager or clone directly into your package.
 {
     "NvChad/nvim-colorizer.lua",
     event = "BufReadPre",
-    opts = { -- setup opts
+    opts = { -- set to setup table
     },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -132,29 +132,33 @@ library to do custom highlighting themselves.
       hsl_fn = false, -- CSS hsl() and hsla() functions
       css = false, -- Enable all CSS features: rgb_fn, hsl_fn, names, RGB, RRGGBB
       css_fn = false, -- Enable all CSS *functions*: rgb_fn, hsl_fn
-      -- Available modes for `mode`: foreground, background,  virtualtext
-      mode = "background", -- Set the display mode.
-      -- Available methods are false / true / "normal" / "lsp" / "both"
-      -- True is same as normal
+      -- Highlighting mode.  'background'|'foreground'|'virtualtext'
+      mode = "background", -- Set the display mode
+      -- Tailwind colors.  boolean|'normal'|'lsp'|'both'.  True is same as normal
       tailwind = false, -- Enable tailwind colors
       -- parsers can contain values used in |user_default_options|
       sass = { enable = false, parsers = { "css" } }, -- Enable sass colors
+      -- Virtualtext character to use
       virtualtext = "■",
+      -- Display virtualtext inline with color
+      virtualtext_inline = false,
+      -- Virtualtext highlight mode: 'background'|'foreground'
+      virtualtext_mode = "foreground",
       -- update color values even if buffer is not focused
       -- example use: cmp_menu, cmp_docs
       always_update = false,
     },
     -- all the sub-options of filetypes apply to buftypes
     buftypes = {},
-    user_commands = true, -- Enable all or some usercommands
     -- Boolean | List of usercommands to enable
+    user_commands = true, -- Enable all or some usercommands
   })
 ```
 
 MODES:
 
-- `foreground`: sets the foreground text color.
 - `background`: sets the background text color.
+- `foreground`: sets the foreground text color.
 - `virtualtext`: indicate the color behind the virtualtext.
 
 For basic setup, you can use a command like the following.

--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -471,7 +471,7 @@ get_options({bo_type}, {buftype}, {filetype})     *colorizer.config.get_options*
     Retrieve options based on buffer type and file type.
 
     Parameters: ~
-	{bo_type} -  'filetype' | 'buftype': Type of buffer option
+	{bo_type} -  'buftype'|'filetype': The type of buffer option
 	{buftype} -  string: Buffer type.
 	{filetype} -  string: File type.
 
@@ -484,7 +484,7 @@ set_bo_value({bo_type}, {value}, {options})      *colorizer.config.set_bo_value*
     Set options for a specific buffer or file type.
 
     Parameters: ~
-	{bo_type} -  'filetype' | 'buftype': Type of buffer option
+	{bo_type} -  'buftype'|'filetype': The type of buffer option
 	{value} -  string: The specific value to set.
 	{options} -  table: Options to associate with the value.
 
@@ -534,13 +534,14 @@ user_default_options                     *colorizer.config.user_default_options*
 	{css} -  boolean: Enables all CSS features (`rgb_fn`, `hsl_fn`, `names`,
 	`RGB`, `RRGGBB`).
 	{css_fn} -  boolean: Enables all CSS functions (`rgb_fn`, `hsl_fn`).
-	{mode} -  string: Display mode (e.g., "background", "foreground",
-	"virtualtext").
+	{mode} -  'background'|'foreground'|'virtualtext': Display mode
 	{tailwind} -  boolean|string: Enables Tailwind CSS colors (e.g.,
 	`"normal"`, `"lsp"`, `"both"`).
 	{sass} -  table: Sass color configuration (`enable` flag and `parsers`).
 	{virtualtext} -  string: Character used for virtual text display.
 	{virtualtext_inline} -  boolean: Shows virtual text inline with color.
+	{virtualtext_mode} -  'background'|'foreground': Mode for virtual text
+	display.
 	{always_update} -  boolean: Always update color values, even if buffer
 	is not focused.
 
@@ -575,6 +576,8 @@ opts                                                     *colorizer.config.opts*
      (default is `"■"`).
    - `virtualtext_inline` (boolean): If true, shows the virtual text inline with
      the color.
+ - `virtualtext_mode` ('background'|'foreground'): Determines the display mode
+   for virtual text.
    - `always_update` (boolean): If true, updates color values even if the buffer
      is not focused.
 	{buftypes} -  table|nil Optional. A list of buffer types where colorizer

--- a/doc/colorizer.txt
+++ b/doc/colorizer.txt
@@ -458,12 +458,12 @@ get_settings({opts})                             *colorizer.config.get_settings*
 
 
 
-new_buffer_options({bufnr}, {option_type}) *colorizer.config.new_buffer_options*
+new_buffer_options({bufnr}, {bo_type})     *colorizer.config.new_buffer_options*
     Retrieve default options or buffer-specific options.
 
     Parameters: ~
 	{bufnr} -  number: The buffer number.
-	{option_type} -  string: The option type to retrieve.
+	{bo_type} -  'buftype'|'filetype': The type of buffer option
 
 
 
@@ -474,6 +474,9 @@ get_options({bo_type}, {buftype}, {filetype})     *colorizer.config.get_options*
 	{bo_type} -  'filetype' | 'buftype': Type of buffer option
 	{buftype} -  string: Buffer type.
 	{filetype} -  string: File type.
+
+    returns:~
+	table, table
 
 
 

--- a/doc/modules/colorizer.config.html
+++ b/doc/modules/colorizer.config.html
@@ -169,7 +169,7 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">bo_type</span>
-         'filetype' | 'buftype': Type of buffer option
+         'buftype'|'filetype': The type of buffer option
         </li>
         <li><span class="parameter">buftype</span>
          string: Buffer type.
@@ -200,7 +200,7 @@
     <h3>Parameters:</h3>
     <ul>
         <li><span class="parameter">bo_type</span>
-         'filetype' | 'buftype': Type of buffer option
+         'buftype'|'filetype': The type of buffer option
         </li>
         <li><span class="parameter">value</span>
          string: The specific value to set.
@@ -291,7 +291,7 @@
          boolean: Enables all CSS functions (`rgb_fn`, `hsl_fn`).
         </li>
         <li><span class="parameter">mode</span>
-         string: Display mode (e.g., "background", "foreground", "virtualtext").
+         'background'|'foreground'|'virtualtext': Display mode
         </li>
         <li><span class="parameter">tailwind</span>
          boolean|string: Enables Tailwind CSS colors (e.g., `"normal"`, `"lsp"`, `"both"`).
@@ -304,6 +304,9 @@
         </li>
         <li><span class="parameter">virtualtext_inline</span>
          boolean: Shows virtual text inline with color.
+        </li>
+        <li><span class="parameter">virtualtext_mode</span>
+         'background'|'foreground': Mode for virtual text display.
         </li>
         <li><span class="parameter">always_update</span>
          boolean: Always update color values, even if buffer is not focused.
@@ -346,6 +349,7 @@
       - `parsers` (table): A list of parsers to use, typically includes `"css"`.
    - `virtualtext` (string): Character used for virtual text display of colors (default is `"■"`).
    - `virtualtext_inline` (boolean): If true, shows the virtual text inline with the color.
+ - `virtualtext_mode` ('background'|'foreground'): Determines the display mode for virtual text.
    - `always_update` (boolean): If true, updates color values even if the buffer is not focused.
         </li>
         <li><span class="parameter">buftypes</span>

--- a/doc/modules/colorizer.config.html
+++ b/doc/modules/colorizer.config.html
@@ -73,7 +73,7 @@
 	<td class="summary">Initializes colorizer with user-provided options.</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#new_buffer_options">new_buffer_options (bufnr, option_type)</a></td>
+	<td class="name" nowrap><a href="#new_buffer_options">new_buffer_options (bufnr, bo_type)</a></td>
 	<td class="summary">Retrieve default options or buffer-specific options.</td>
 	</tr>
 	<tr>
@@ -137,7 +137,7 @@
 </dd>
     <dt>
     <a name = "new_buffer_options"></a>
-    <strong>new_buffer_options (bufnr, option_type)</strong>
+    <strong>new_buffer_options (bufnr, bo_type)</strong>
     </dt>
     <dd>
     Retrieve default options or buffer-specific options.
@@ -148,8 +148,8 @@
         <li><span class="parameter">bufnr</span>
          number: The buffer number.
         </li>
-        <li><span class="parameter">option_type</span>
-         string: The option type to retrieve.
+        <li><span class="parameter">bo_type</span>
+         'buftype'|'filetype': The type of buffer option
         </li>
     </ul>
 
@@ -179,6 +179,11 @@
         </li>
     </ul>
 
+    <h3>Returns:</h3>
+    <ol>
+
+        table, table
+    </ol>
 
 
 

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -400,7 +400,7 @@ function M.setup(opts)
   local function setup(bo_type)
     local filetype = vim.bo.filetype
     local buftype = vim.bo.buftype
-    local bufnr = vim.api.nvim_get_current_buf()
+    local bufnr = utils.bufme()
     colorizer_state.buffer_local[bufnr] = colorizer_state.buffer_local[bufnr] or {}
 
     if s.exclusions.filetype[filetype] or s.exclusions.buftype[buftype] then
@@ -431,7 +431,7 @@ function M.setup(opts)
     end
   end
 
-  local aucmd = { buftype = "BufWinEnter", filetype = "FileType" }
+  local events = { buftype = "BufWinEnter", filetype = "FileType" }
   local function parse_opts(bo_type, tbl)
     if type(tbl) == "table" then
       local list = {}
@@ -460,7 +460,7 @@ function M.setup(opts)
           end
         end
       end
-      vim.api.nvim_create_autocmd({ aucmd[bo_type] }, {
+      vim.api.nvim_create_autocmd({ events[bo_type] }, {
         group = colorizer_state.augroup,
         pattern = bo_type == "filetype" and (s.all[bo_type] and "*" or list) or nil,
         callback = function()

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -225,6 +225,7 @@ function M.attach_to_buffer(bufnr, options, bo_type)
     colorizer_state.buffer_local[bufnr], colorizer_state.buffer_options[bufnr] = nil, nil
     return
   end
+
   -- set options by grabbing existing or creating new options, then parsing
   options = config.parse_buffer_options(
     options or get_buffer_options(bufnr) or config.new_buffer_options(bufnr, bo_type)

--- a/lua/colorizer.lua
+++ b/lua/colorizer.lua
@@ -218,7 +218,9 @@ end
 ---@param bo_type 'buftype'|'filetype'|nil: The type of buffer option
 function M.attach_to_buffer(bufnr, options, bo_type)
   bufnr = utils.bufme(bufnr)
-  bo_type = bo_type or "buftype"
+  if not bo_type or not vim.tbl_contains({ "buftype", "filetype" }, bo_type) then
+    bo_type = "buftype"
+  end
   if not vim.api.nvim_buf_is_valid(bufnr) then
     colorizer_state.buffer_local[bufnr], colorizer_state.buffer_options[bufnr] = nil, nil
     return

--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -38,6 +38,9 @@ local function make_highlight_name(rgb, mode)
   return table.concat({ hl_state.name_prefix, M.highlight_mode_names[mode], rgb }, "_")
 end
 
+--- Create a highlight with the given rgb_hex and mode
+---@param rgb_hex string: RGB hex code
+---@param mode 'background'|'foreground': Mode of the highlight
 local function create_highlight(rgb_hex, mode)
   mode = mode or "background"
   -- TODO validate rgb format?
@@ -88,18 +91,17 @@ end
 function M.add_highlight(bufnr, ns_id, line_start, line_end, data, options)
   vim.api.nvim_buf_clear_namespace(bufnr, ns_id, line_start, line_end)
 
-  local mode = options.mode == "background" and "background" or "foreground"
-  if vim.tbl_contains({ "foreground", "background" }, options.mode) then
+  if vim.tbl_contains({ "background", "foreground" }, options.mode) then
     for linenr, hls in pairs(data) do
       for _, hl in ipairs(hls) do
-        local hlname = create_highlight(hl.rgb_hex, mode)
+        local hlname = create_highlight(hl.rgb_hex, options.mode)
         vim.api.nvim_buf_add_highlight(bufnr, ns_id, hlname, linenr, hl.range[1], hl.range[2])
       end
     end
   elseif options.mode == "virtualtext" then
     for linenr, hls in pairs(data) do
       for _, hl in ipairs(hls) do
-        local hlname = create_highlight(hl.rgb_hex, mode)
+        local hlname = create_highlight(hl.rgb_hex, options.virtualtext_mode)
 
         local start_col = hl.range[2]
         local opts = {

--- a/lua/colorizer/buffer.lua
+++ b/lua/colorizer/buffer.lua
@@ -7,6 +7,7 @@ local color = require("colorizer.color")
 local plugin_name = "colorizer"
 local sass = require("colorizer.sass")
 local tailwind = require("colorizer.tailwind")
+local utils = require("colorizer.utils")
 local make_matcher = require("colorizer.matcher").make
 
 local hl_state = {
@@ -134,7 +135,7 @@ end
 function M.highlight(bufnr, ns_id, line_start, line_end, options, options_local)
   local returns = { detach = { ns_id = {}, functions = {} } }
   if bufnr == 0 or bufnr == nil then
-    bufnr = vim.api.nvim_get_current_buf()
+    bufnr = utils.bufme()
   end
 
   local lines = vim.api.nvim_buf_get_lines(bufnr, line_start, line_end, false)

--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -4,6 +4,29 @@ local M = {}
 
 local utils = require("colorizer.utils")
 
+--- Defaults for colorizer options
+local _user_defaults = {
+  RGB = true,
+  RRGGBB = true,
+  names = true,
+  RRGGBBAA = false,
+  AARRGGBB = false,
+  rgb_fn = false,
+  hsl_fn = false,
+  css = false,
+  css_fn = false,
+  mode = "background",
+  tailwind = false,
+  sass = { enable = false, parsers = { css = true } },
+  virtualtext = "■",
+  virtualtext_inline = false,
+  virtualtext_mode = "foreground",
+  always_update = false,
+}
+local function user_defaults()
+  return vim.deepcopy(_user_defaults)
+end
+
 --- Default user options for colorizer.
 -- This table defines individual options and alias options, allowing configuration of
 -- colorizer's behavior for different color formats (e.g., `#RGB`, `#RRGGBB`, `#AARRGGBB`, etc.).
@@ -27,11 +50,12 @@ local utils = require("colorizer.utils")
 -- @field hsl_fn boolean: Enables CSS `hsl()` and `hsla()` functions.
 -- @field css boolean: Enables all CSS features (`rgb_fn`, `hsl_fn`, `names`, `RGB`, `RRGGBB`).
 -- @field css_fn boolean: Enables all CSS functions (`rgb_fn`, `hsl_fn`).
--- @field mode string: Display mode (e.g., "background", "foreground", "virtualtext").
+-- @field mode 'background'|'foreground'|'virtualtext': Display mode
 -- @field tailwind boolean|string: Enables Tailwind CSS colors (e.g., `"normal"`, `"lsp"`, `"both"`).
 -- @field sass table: Sass color configuration (`enable` flag and `parsers`).
 -- @field virtualtext string: Character used for virtual text display.
 -- @field virtualtext_inline boolean: Shows virtual text inline with color.
+-- @field virtualtext_mode 'background'|'foreground': Mode for virtual text display.
 -- @field always_update boolean: Always update color values, even if buffer is not focused.
 
 -- Default options for the user
@@ -45,34 +69,44 @@ local utils = require("colorizer.utils")
 --@field hsl_fn boolean
 --@field css boolean
 --@field css_fn boolean
---@field mode string
+--@field mode 'background'|'foreground'|'virtualtext'
 --@field tailwind boolean|string
 --@field sass table
 --@field virtualtext string
---@field virtualtext_inline? boolean
+--@field virtualtext_inline boolean
+--@field virtualtext_mode 'background'|'foreground'
 --@field always_update boolean
-M.user_default_options = {
-  RGB = true,
-  RRGGBB = true,
-  names = true,
-  RRGGBBAA = false,
-  AARRGGBB = false,
-  rgb_fn = false,
-  hsl_fn = false,
-  css = false,
-  css_fn = false,
-  mode = "background",
-  tailwind = false,
-  sass = { enable = false, parsers = { css = true } },
-  virtualtext = "■",
-  virtualtext_inline = false,
-  always_update = false,
-}
-
---  TODO: 2024-11-10 - check if setup() works
+M.user_default_options = user_defaults()
 
 -- State for managing buffer and filetype-specific options
 local options_state = { buftype = {}, filetype = {} }
+
+--  TODO: 2024-11-20 - use vim.validate?
+--- Validates user options and sets defaults if necessary.
+local function validate_opts(settings)
+  if
+    not vim.tbl_contains(
+      { "background", "foreground", "virtualtext" },
+      settings.default_options.mode
+    )
+  then
+    settings.default_options.mode = M.user_default_options.mode
+  end
+  if
+    not vim.tbl_contains({ "background", "foreground" }, settings.default_options.virtualtext_mode)
+  then
+    settings.default_options.virtualtext_mode = M.user_default_options.virtualtext_mode
+  end
+  if
+    not vim.tbl_contains(
+      { true, false, "normal", "lsp", "both" },
+      settings.default_options.tailwind
+    )
+  then
+    settings.default_options.tailwind = M.user_default_options.tailwind
+  end
+  return settings
+end
 
 --- Configuration options for the `setup` function.
 -- @table opts
@@ -94,6 +128,7 @@ local options_state = { buftype = {}, filetype = {} }
 --      - `parsers` (table): A list of parsers to use, typically includes `"css"`.
 --   - `virtualtext` (string): Character used for virtual text display of colors (default is `"■"`).
 --   - `virtualtext_inline` (boolean): If true, shows the virtual text inline with the color.
+-- - `virtualtext_mode` ('background'|'foreground'): Determines the display mode for virtual text.
 --   - `always_update` (boolean): If true, updates color values even if the buffer is not focused.
 -- @field buftypes table|nil Optional. A list of buffer types where colorizer should be enabled. Defaults to all buffer types if not provided.
 -- @field user_commands boolean|table If true, enables all user commands for colorizer. If `false`, disables user commands. Alternatively, provide a table of specific commands to enable:
@@ -109,13 +144,13 @@ local options_state = { buftype = {}, filetype = {} }
 -- @return table Final settings after merging user and default options.
 function M.get_settings(opts)
   opts = opts or {}
-  local defaults = {
+  local default_opts = {
     filetypes = { "*" },
     buftypes = nil,
     user_commands = true,
-    user_default_options = M.user_default_options,
+    user_default_options = user_defaults(),
   }
-  opts = vim.tbl_deep_extend("force", defaults, opts)
+  opts = vim.tbl_deep_extend("force", default_opts, opts)
   local settings = {
     exclusions = { buftype = {}, filetype = {} },
     all = { buftype = false, filetype = false },
@@ -128,6 +163,8 @@ function M.get_settings(opts)
     filetypes = opts.filetypes,
     buftypes = opts.buftypes,
   }
+  validate_opts(settings)
+
   return settings
 end
 
@@ -140,7 +177,7 @@ function M.new_buffer_options(bufnr, bo_type)
 end
 
 --- Retrieve options based on buffer type and file type.
----@param bo_type 'filetype' | 'buftype': Type of buffer option
+---@param bo_type 'buftype'|'filetype': The type of buffer option
 ---@param buftype string: Buffer type.
 ---@param filetype string: File type.
 ---@return table, table
@@ -149,7 +186,7 @@ function M.get_options(bo_type, buftype, filetype)
 end
 
 --- Set options for a specific buffer or file type.
----@param bo_type 'filetype' | 'buftype': Type of buffer option
+---@param bo_type 'buftype'|'filetype': The type of buffer option
 ---@param value string: The specific value to set.
 ---@param options table: Options to associate with the value.
 function M.set_bo_value(bo_type, value, options)

--- a/lua/colorizer/config.lua
+++ b/lua/colorizer/config.lua
@@ -133,9 +133,9 @@ end
 
 --- Retrieve default options or buffer-specific options.
 ---@param bufnr number: The buffer number.
----@param option_type string: The option type to retrieve.
-function M.new_buffer_options(bufnr, option_type)
-  local value = vim.api.nvim_get_option_value(option_type, { buf = bufnr })
+---@param bo_type 'buftype'|'filetype': The type of buffer option
+function M.new_buffer_options(bufnr, bo_type)
+  local value = vim.api.nvim_get_option_value(bo_type, { buf = bufnr })
   return options_state.filetype[value] or M.user_default_options
 end
 
@@ -143,8 +143,9 @@ end
 ---@param bo_type 'filetype' | 'buftype': Type of buffer option
 ---@param buftype string: Buffer type.
 ---@param filetype string: File type.
+---@return table, table
 function M.get_options(bo_type, buftype, filetype)
-  return options_state[bo_type][filetype], options_state[bo_type][buftype]
+  return options_state[bo_type][buftype], options_state[bo_type][filetype]
 end
 
 --- Set options for a specific buffer or file type.

--- a/lua/colorizer/matcher.lua
+++ b/lua/colorizer/matcher.lua
@@ -42,7 +42,7 @@ local function compile(matchers, matchers_trie)
     -- prefix $, SASS Color names
     if matchers.sass_name_parser then
       if line:byte(i) == ("$"):byte() then
-        return sass_name_parser(line, i, buf)
+        return sass_name_parser(line, i, bufnr)
       end
     end
 

--- a/lua/colorizer/usercmds.lua
+++ b/lua/colorizer/usercmds.lua
@@ -9,7 +9,9 @@ local M = {}
 -- @param name string The name of the command to create
 -- @param f function The function to execute when the command is run
 local wrap = function(name, f)
-  vim.api.nvim_create_user_command(name, f, {})
+  vim.api.nvim_create_user_command(name, function()
+    f()
+  end, {})
 end
 
 --- Create user commands for Colorizer based on the given command list.
@@ -26,24 +28,16 @@ function M.make(cmds)
   end
   local c = require("colorizer")
   local cmd_list = {
-    ColorizerAttachToBuffer = function()
-      wrap("ColorizerAttachToBuffer", c.attach_to_buffer)
-    end,
-    ColorizerDetachFromBuffer = function()
-      wrap("ColorizerDetachFromBuffer", c.detach_from_buffer)
-    end,
-    ColorizerReloadAllBuffers = function()
-      wrap("ColorizerReloadAllBuffers", c.reload_all_buffers)
-    end,
-    ColorizerToggle = function()
-      wrap("ColorizerToggle", function()
-        if c.is_buffer_attached() then
-          c.detach_from_buffer()
-        else
-          c.attach_to_buffer()
-        end
-      end)
-    end,
+    ColorizerAttachToBuffer = wrap("ColorizerAttachToBuffer", c.attach_to_buffer),
+    ColorizerDetachFromBuffer = wrap("ColorizerDetachFromBuffer", c.detach_from_buffer),
+    ColorizerReloadAllBuffers = wrap("ColorizerReloadAllBuffers", c.reload_all_buffers),
+    ColorizerToggle = wrap("ColorizerToggle", function()
+      if c.is_buffer_attached() then
+        c.detach_from_buffer()
+      else
+        c.attach_to_buffer()
+      end
+    end),
   }
 
   if type(cmds) == "boolean" and cmds then

--- a/lua/colorizer/usercmds.lua
+++ b/lua/colorizer/usercmds.lua
@@ -24,19 +24,19 @@ function M.make(cmds)
   if not cmds then
     return
   end
+  local c = require("colorizer")
   local cmd_list = {
     ColorizerAttachToBuffer = function()
-      wrap("ColorizerAttachToBuffer", require("colorizer").attach_to_buffer)
+      wrap("ColorizerAttachToBuffer", c.attach_to_buffer)
     end,
     ColorizerDetachFromBuffer = function()
-      wrap("ColorizerDetachFromBuffer", require("colorizer").detach_from_buffer)
+      wrap("ColorizerDetachFromBuffer", c.detach_from_buffer)
     end,
     ColorizerReloadAllBuffers = function()
-      wrap("ColorizerReloadAllBuffers", require("colorizer").reload_all_buffers)
+      wrap("ColorizerReloadAllBuffers", c.reload_all_buffers)
     end,
     ColorizerToggle = function()
       wrap("ColorizerToggle", function()
-        local c = require("colorizer")
         if c.is_buffer_attached() then
           c.detach_from_buffer()
         else

--- a/scripts/start_minimal.sh
+++ b/scripts/start_minimal.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cd test || exit
-nvim --clean -u minimal.lua expect.txt
+nvim --clean -u minimal.lua

--- a/test/expect.txt
+++ b/test/expect.txt
@@ -1,10 +1,25 @@
 -- vim:ft=lua
-require("colorizer").detach_from_buffer()
-require("colorizer").attach_to_buffer(0, {
+return {
+  RGB = true,
+  RRGGBB = true,
+  names = true,
+  RRGGBBAA = true,
   AARRGGBB = true,
+  rgb_fn = true,
+  hsl_fn = true,
   css = true,
-  mode = "foreground",
-})
+  css_fn = true,
+  mode = "background",
+  tailwind = "normal",
+  sass = {
+    enable = false,
+    parsers = { "css" },
+  },
+  virtualtext = "■",
+  virtualtext_inline = false,
+  virtualtext_mode = "foreground",
+  always_update = false,
+}
 --[[ SUCCESS
 0xFf32A14B 0xFf32A14B
 0x1B29FB 0x1B29FB

--- a/test/expect.txt
+++ b/test/expect.txt
@@ -6,9 +6,9 @@ require("colorizer").attach_to_buffer(0, {
   mode = "foreground",
 })
 --[[ SUCCESS
-0xFf32A14B 0xFf32A14B 
-0x1B29FB 0x1B29FB 
-0xF0F 0xF0F 
+0xFf32A14B 0xFf32A14B
+0x1B29FB 0x1B29FB
+0xF0F 0xF0F
 0xA3B67CDE 0x7F12D9A5 0x7E43F2 0x34E8D3 0xB3A 0x1CD
 
 #32a14b
@@ -28,9 +28,9 @@ White
 
 rgb(    31     12.90   50 /0.5) rgb(   10, 100 ,      100, 0.3)
 rgb(30% 20% 50%) rgb(0,0,0) rgb(255 122 127 / 80%)
-rgb(255 122 127 / .2) rgba(200,30,0,1) rgba(200,30,0,0.5) 
+rgb(255 122 127 / .2) rgba(200,30,0,1) rgba(200,30,0,0.5)
 
-hsl(300 50% 50%) hsl(300 50% 50% / 1) hsl(100 80% 50% / 0.4) 
+hsl(300 50% 50%) hsl(300 50% 50% / 1) hsl(100 80% 50% / 0.4)
 hsl(990 80% 50% / 0.4) hsl(720 80% 50% / 0.4)
 hsl(1turn 80% 50% / 0.4) hsl(0.4turn 80% 50% / 0.4) hsl(1.4turn 80% 50% / 0.4)
 hsla(300 50% 50%) hsla(300 50% 50% / 1)
@@ -39,9 +39,9 @@ hsla(360   ,  50%  ,  50%   ,  1.0000000000000001)
 ]]
 
 --[[ FAIL
-0xf32A14B 0xf32A14B 
-0xB29FB 0xB29FB 
-0x0F 0x0F 
+0xf32A14B 0xf32A14B
+0xB29FB 0xB29FB
+0x0F 0x0F
 0x3B67CDE 0xF12D9A5 0xE43F2 0x4E8D3 0x3A 0xCD
 #---
 #F0FF

--- a/test/minimal.lua
+++ b/test/minimal.lua
@@ -23,12 +23,15 @@ local opts = {
     css = true,
     css_fn = true,
     mode = "background",
-    tailwind = "lsp",
+    tailwind = "normal",
     sass = {
       enable = false,
       parsers = { "css" },
     },
     virtualtext = "■",
+    virtualtext_inline = false,
+    virtualtext_mode = "foreground",
+    always_update = false,
   },
   buftypes = { "!prompt", "!popup" },
   user_commands = true,
@@ -36,3 +39,8 @@ local opts = {
 require("colorizer").setup(opts)
 
 -- ADD INIT.LUA SETTINGS _NECESSARY_ FOR REPRODUCING THE ISSUE
+
+vim.schedule(function()
+  vim.cmd("leftabove vsplit minimal.lua")
+  vim.cmd("edit tailwind.html")
+end)

--- a/test/minimal.lua
+++ b/test/minimal.lua
@@ -1,4 +1,11 @@
--- Run this file as `nvim --clean -u minimal.lua expect.txt`
+-- Run this file as `nvim --clean -u minimal.lua`
+
+-- local local_plugin_dir = os.getenv("HOME") .. "/git/nvim-colorizer.lua"
+-- if vim.fn.isdirectory(local_plugin_dir) == 1 then
+--   vim.opt.runtimepath:append(local_plugin_dir)
+-- else
+--   vim.notify("Local plugin directory not found: " .. local_plugin_dir, vim.log.levels.ERROR)
+-- end
 
 for name, url in pairs({
   colorizer = "https://github.com/NvChad/nvim-colorizer.lua",
@@ -11,7 +18,7 @@ for name, url in pairs({
 end
 
 -- Configure setup opts
-local opts = {
+local setup_opts = {
   user_default_options = {
     RGB = true,
     RRGGBB = true,
@@ -36,11 +43,45 @@ local opts = {
   buftypes = { "!prompt", "!popup" },
   user_commands = true,
 }
-require("colorizer").setup(opts)
+require("colorizer").setup(setup_opts)
+
+vim.api.nvim_create_autocmd("BufWritePost", {
+  pattern = "expect.txt", -- Ensure this matches your file name
+  callback = function(evt)
+    vim.schedule(function()
+      local file_path = evt.match
+
+      if not file_path or file_path == "" then
+        vim.notify("Could not determine the file path", vim.log.levels.ERROR)
+        return
+      end
+
+      local opts
+      local success, err = pcall(function()
+        opts = dofile(file_path) -- Dynamically execute the saved file
+      end)
+
+      if not success then
+        vim.notify("Error reloading file: " .. err, vim.log.levels.ERROR)
+        return
+      end
+
+      if not opts or type(opts) ~= "table" then
+        vim.notify("Invalid options in " .. file_path, vim.log.levels.ERROR)
+        return
+      end
+
+      require("colorizer").detach_from_buffer(evt.buf)
+      require("colorizer").attach_to_buffer(evt.buf, opts)
+
+      vim.notify("Colorizer reloaded with updated options from " .. file_path, vim.log.levels.INFO)
+    end)
+  end,
+})
+
+vim.cmd.edit("tailwind.html")
+vim.schedule(function()
+  vim.cmd("leftabove vsplit expect.txt")
+end)
 
 -- ADD INIT.LUA SETTINGS _NECESSARY_ FOR REPRODUCING THE ISSUE
-
-vim.schedule(function()
-  vim.cmd("leftabove vsplit minimal.lua")
-  vim.cmd("edit tailwind.html")
-end)


### PR DESCRIPTION
- virtualtext mode (`background|foreground`) can be configured in setup opts
- running `minimal.lua` opens `expect.txt` and `tailwind.html`.  saving `expect.txt` reloads setting defined in the return statement